### PR TITLE
Rename SemidefiniteModel -> SemidefiniteModels

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.5
 BinDeps
 Glob
 MathProgBase
-SemidefiniteModel
+SemidefiniteModels

--- a/src/CSDPSolverInterface.jl
+++ b/src/CSDPSolverInterface.jl
@@ -1,5 +1,5 @@
 importall MathProgBase.SolverInterface
-importall SemidefiniteModel
+importall SemidefiniteModels
 
 export CSDPMathProgModel, CSDPSolver
 


### PR DESCRIPTION
I have registered `JuliaOpt/SemidefiniteModels` which should be used instead of `blegat/SemidefiniteModel`