### PR TITLE
Bump CSDP_jll to v600.200.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "0.5.9"
-CSDP_jll = "=600.200.1"
+CSDP_jll = "=6.2.0, =600.200.1"
 Glob = "1.2"
 MathOptInterface = "0.10"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "0.5.9"
-CSDP_jll = "=6.2.0"
+CSDP_jll = "=600.200.1"
 Glob = "1.2"
 MathOptInterface = "0.10"
 julia = "1"


### PR DESCRIPTION
@odow I noticed you keep the old jll's in the Compat (e.g., in https://github.com/jump-dev/Ipopt.jl/pull/294/). What's the reasoning behind this ? We want to force using the new jll so that we are usre it works on Mac OS ARM right ?