### PR TITLE
Remove incorrect ConstraintPrimal method in favor of fallback

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -568,19 +568,6 @@ end
 
 function MOI.get(
     model::Optimizer,
-    attr::MOI.ConstraintPrimal,
-    ci::MOI.ConstraintIndex{
-        MOI.ScalarAffineFunction{Cdouble},
-        MOI.EqualTo{Cdouble},
-    },
-)
-    MOI.check_result_index_bounds(model, attr)
-    # TODO(odow): this isn't correct. In Ax = b, it should be Ax, not b.
-    return model.b[ci.value]
-end
-
-function MOI.get(
-    model::Optimizer,
     attr::MOI.ConstraintDual,
     ci::MOI.ConstraintIndex{MOI.VectorOfVariables,S},
 ) where {S<:SupportedSets}


### PR DESCRIPTION
This is technically breaking, but it's currently incorrect, and most users should be using the cache (in which case, it isn't breaking).

Thoughts @blegat?