### PR TITLE
Add infeasibility certificate back

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -505,22 +505,28 @@ MOI.get(model::Optimizer, ::MOI.SolveTimeSec) = model.solve_time
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
-    if MOI.get(model, MOI.PrimalStatus(attr.result_index)) == MOI.INFEASIBILITY_CERTIFICATE
-        throw(MOI.GetAttributeNotAllowed(
-            attr,
-            "CSDP does not support getting the objective value corresponding to a certificate of dual infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the value of the variables.",
-        ))
+    if MOI.get(model, MOI.PrimalStatus(attr.result_index)) ==
+       MOI.INFEASIBILITY_CERTIFICATE
+        throw(
+            MOI.GetAttributeNotAllowed(
+                attr,
+                "CSDP does not support getting the objective value corresponding to a certificate of dual infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the value of the variables.",
+            ),
+        )
     end
     return model.objective_sign * model.pobj
 end
 
 function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
-    if MOI.get(model, MOI.DualStatus(attr.result_index)) == MOI.INFEASIBILITY_CERTIFICATE
-        throw(MOI.GetAttributeNotAllowed(
-            attr,
-            "CSDP does not support getting the dual objective value corresponding to a certificate of primal infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the dual value of the constraints.",
-        ))
+    if MOI.get(model, MOI.DualStatus(attr.result_index)) ==
+       MOI.INFEASIBILITY_CERTIFICATE
+        throw(
+            MOI.GetAttributeNotAllowed(
+                attr,
+                "CSDP does not support getting the dual objective value corresponding to a certificate of primal infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the dual value of the constraints.",
+            ),
+        )
     end
     return model.objective_sign * model.dobj
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -474,8 +474,8 @@ function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
         return MOI.FEASIBLE_POINT
     elseif model.status == 1
         return MOI.INFEASIBLE_POINT
-        # elseif model.status == 2
-        #     return MOI.INFEASIBILITY_CERTIFICATE
+    elseif model.status == 2
+        return MOI.INFEASIBILITY_CERTIFICATE
     elseif model.status == 3
         return MOI.NEARLY_FEASIBLE_POINT
     else
@@ -490,8 +490,8 @@ function MOI.get(model::Optimizer, attr::MOI.DualStatus)
         return MOI.NO_SOLUTION
     elseif model.status == 0
         return MOI.FEASIBLE_POINT
-        # elseif model.status == 1
-        #     return MOI.INFEASIBILITY_CERTIFICATE
+    elseif model.status == 1
+        return MOI.INFEASIBILITY_CERTIFICATE
     elseif model.status == 2
         return MOI.INFEASIBLE_POINT
     elseif model.status == 3

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -505,11 +505,23 @@ MOI.get(model::Optimizer, ::MOI.SolveTimeSec) = model.solve_time
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
+    if MOI.get(model, MOI.PrimalStatus(attr.result_index)) == MOI.INFEASIBILITY_CERTIFICATE
+        throw(MOI.GetAttributeNotAllowed(
+            attr,
+            "CSDP does not support getting the objective value corresponding to a certificate of dual infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the value of the variables.",
+        ))
+    end
     return model.objective_sign * model.pobj
 end
 
 function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
+    if MOI.get(model, MOI.DualStatus(attr.result_index)) == MOI.INFEASIBILITY_CERTIFICATE
+        throw(MOI.GetAttributeNotAllowed(
+            attr,
+            "CSDP does not support getting the dual objective value corresponding to a certificate of primal infeasibility. Use a `MOI.Utilities.CachingOptimizer` layer so that it gets automatically computed from the dual value of the constraints.",
+        ))
+    end
     return model.objective_sign * model.dobj
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -105,6 +105,22 @@ function test_runtests()
             "test_solve_result_index",
             "test_solve_TerminationStatus_DUAL_INFEASIBLE",
             "test_variable_solve_with_lowerbound",
+            # TODO CSDP just returns an infinite ObjectiveValue
+            # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
+            "test_unbounded_MIN_SENSE",
+            "test_unbounded_MIN_SENSE_offset",
+            "test_unbounded_MAX_SENSE",
+            "test_unbounded_MAX_SENSE_offset",
+            # TODO CSDP just returns an infinite DualObjectiveValue
+            # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
+            "test_infeasible_MAX_SENSE",
+            "test_infeasible_MAX_SENSE_offset",
+            "test_infeasible_MIN_SENSE",
+            "test_infeasible_MIN_SENSE_offset",
+            "test_infeasible_affine_MAX_SENSE",
+            "test_infeasible_affine_MAX_SENSE_offset",
+            "test_infeasible_affine_MIN_SENSE",
+            "test_infeasible_affine_MIN_SENSE_offset",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -78,49 +78,13 @@ function test_runtests()
             #   Empty constraint not supported:
             "test_conic_PositiveSemidefiniteConeTriangle",
             "test_linear_VectorAffineFunction_empty_row",
-            #   Unable to bridge RotatedSecondOrderCone to PSD because the ...
+            #   Unable to bridge RotatedSecondOrderCone to PSD because the the dimension is too small: got 2, expected >= 3
             "test_conic_SecondOrderCone_INFEASIBLE",
             "test_constraint_PrimalStart_DualStart_SecondOrderCone",
             # TODO(odow): unknown test failures.
             "test_conic_RotatedSecondOrderCone_VectorOfVariables",
-            "test_conic_SecondOrderCone_negative_initial_bound",
-            "test_conic_SecondOrderCone_negative_post_bound",
-            "test_conic_SecondOrderCone_negative_post_bound_2",
-            "test_conic_SecondOrderCone_negative_post_bound_3",
-            "test_conic_SecondOrderCone_nonnegative_initial_bound",
-            "test_conic_SecondOrderCone_no_initial_bound",
-            "test_modification_coef_scalar_objective",
-            "test_modification_const_scalar_objective",
-            "test_modification_delete_variables_in_a_batch",
-            "test_modification_delete_variable_with_single_variable_obj",
-            "test_modification_set_singlevariable_lessthan",
-            "test_modification_transform_singlevariable_lessthan",
-            "test_objective_FEASIBILITY_SENSE_clears_objective",
-            "test_objective_ObjectiveFunction_blank",
-            "test_objective_ObjectiveFunction_constant",
-            "test_objective_ObjectiveFunction_duplicate_terms",
-            "test_objective_ObjectiveFunction_VariableIndex",
-            "test_quadratic_constraint_basic",
-            "test_quadratic_constraint_minimize",
-            "test_solve_result_index",
-            "test_solve_TerminationStatus_DUAL_INFEASIBLE",
             "test_variable_solve_with_lowerbound",
-            # TODO CSDP just returns an infinite ObjectiveValue
-            # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
-            "test_unbounded_MIN_SENSE",
-            "test_unbounded_MIN_SENSE_offset",
-            "test_unbounded_MAX_SENSE",
-            "test_unbounded_MAX_SENSE_offset",
-            # TODO CSDP just returns an infinite DualObjectiveValue
-            # See https://github.com/jump-dev/MathOptInterface.jl/issues/1759
-            "test_infeasible_MAX_SENSE",
-            "test_infeasible_MAX_SENSE_offset",
-            "test_infeasible_MIN_SENSE",
-            "test_infeasible_MIN_SENSE_offset",
-            "test_infeasible_affine_MAX_SENSE",
-            "test_infeasible_affine_MAX_SENSE_offset",
-            "test_infeasible_affine_MIN_SENSE",
-            "test_infeasible_affine_MIN_SENSE_offset",
+            "test_modification_delete_variables_in_a_batch",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -85,9 +85,20 @@ function test_runtests()
             "test_conic_RotatedSecondOrderCone_VectorOfVariables",
             "test_variable_solve_with_lowerbound",
             "test_modification_delete_variables_in_a_batch",
-            # Working locally but `SLOW_PROGRESS` in CI
+            # Working locally but getting into numerical issues in CI
             "test_quadratic_constraint_basic",
             "test_quadratic_constraint_minimize",
+            "test_conic_SecondOrderCone_negative_post_bound",
+            "test_conic_SecondOrderCone_no_initial_bound",
+            "test_linear_integration",
+            "test_modification_coef_scalar_objective",
+            "test_modification_const_scalar_objective",
+            "test_modification_delete_variable_with_single_variable_obj",
+            "test_modification_transform_singlevariable_lessthan",
+            "test_objective_FEASIBILITY_SENSE_clears_objective",
+            "test_objective_ObjectiveFunction_blank",
+            "test_objective_ObjectiveFunction_duplicate_terms",
+            "test_solve_result_index",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -85,6 +85,9 @@ function test_runtests()
             "test_conic_RotatedSecondOrderCone_VectorOfVariables",
             "test_variable_solve_with_lowerbound",
             "test_modification_delete_variables_in_a_batch",
+            # Working locally but `SLOW_PROGRESS` in CI
+            "test_quadratic_constraint_basic",
+            "test_quadratic_constraint_minimize",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -99,6 +99,9 @@ function test_runtests()
             "test_objective_ObjectiveFunction_blank",
             "test_objective_ObjectiveFunction_duplicate_terms",
             "test_solve_result_index",
+            "test_modification_set_singlevariable_lessthan",
+            "test_objective_ObjectiveFunction_VariableIndex",
+            "test_conic_SecondOrderCone_nonnegative_initial_bound",
         ],
     )
     return

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -102,6 +102,7 @@ function test_runtests()
             "test_modification_set_singlevariable_lessthan",
             "test_objective_ObjectiveFunction_VariableIndex",
             "test_conic_SecondOrderCone_nonnegative_initial_bound",
+            "test_solve_TerminationStatus_DUAL_INFEASIBLE",
         ],
     )
     return


### PR DESCRIPTION
I seems that was commented out in https://github.com/jump-dev/CSDP.jl/pull/81 so that MOI does not test the objective value at the infeasibility certificates because of https://github.com/jump-dev/MathOptInterface.jl/issues/1759.
However, the certificate at the value was correct so this was quite breaking.
Actually, thanks to https://github.com/jump-dev/MathOptInterface.jl/pull/1893, we can now throw an error that is handled by the CachingOptimizer so we can pass these tests now!
I also enabled many other tests that were passing on my computer